### PR TITLE
Fix linker error to gst_base_sink_get_type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.6)
 
 project(gscam2)
 
@@ -27,9 +27,9 @@ if($ENV{CLION_IDE})
 endif()
 
 # Gstreamer doesn't provide CMake files
-find_package(PkgConfig)
-pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
-pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 IMPORTED_TARGET)
+pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0 IMPORTED_TARGET)
 
 find_package(ament_cmake REQUIRED)
 find_package(camera_calibration_parsers REQUIRED)
@@ -50,21 +50,18 @@ set(node_plugins "")
 # GSCam node
 #=============
 
-set(GSCAM_NODE_SOURCES
-  src/gscam_node.cpp)
-
 set(GSCAM_NODE_DEPS
   camera_calibration_parsers
   camera_info_manager
   class_loader
-  GST_APP
   rclcpp
   rclcpp_components
   ros2_shared
   sensor_msgs)
 
-add_library(gscam_node SHARED
-  ${GSCAM_NODE_SOURCES})
+add_library(gscam_node SHARED)
+target_sources(gscam_node PRIVATE src/gscam_node.cpp)
+add_library(gscam2::gscam_node ALIAS gscam_node)
 
 target_compile_definitions(gscam_node
   PRIVATE "COMPOSITION_BUILDING_DLL")
@@ -72,6 +69,9 @@ target_compile_definitions(gscam_node
 ament_target_dependencies(gscam_node
   ${GSCAM_NODE_DEPS})
 
+target_link_libraries(gscam_node PkgConfig::GSTREAMER PkgConfig::GST_APP)
+target_include_directories(gscam_node PUBLIC
+  "$<BUILD_INTERFACE:${GSTREAMER_INCLUDE_DIRS}>")
 rclcpp_components_register_nodes(gscam_node "gscam2::GSCamNode")
 set(node_plugins "${node_plugins}gscam2::GSCamNode;$<TARGET_FILE:gscam_node>\n")
 
@@ -105,11 +105,12 @@ set(node_plugins "${node_plugins}gscam2::ImageSubscriberNode;$<TARGET_FILE:subsc
 #=============
 
 add_executable(gscam_main
-  src/gscam_main.cpp
-  ${GSCAM_NODE_SOURCES})
+  src/gscam_main.cpp)
 
 ament_target_dependencies(gscam_main
   ${GSCAM_NODE_DEPS})
+
+target_link_libraries(gscam_main gscam2::gscam_node)
 
 #=============
 # Manual composition of camera and subscriber nodes, IPC=true


### PR DESCRIPTION
This should actually fix the #12 by properly linking gstreamer libs. 

* Use PkgConfig populated variables correctly
* Stop linking to strings that aren't targets
* Add alias library for gscam_node

Note: ament_target_dependencies is on its way out in favor of modern cmake calls to `target_link_libraries`. 
https://github.com/ament/ament_cmake/issues/292

It's out of scope of this bug fix, but upgrading to modern cmake in this library would be favorable to make it easier and more robust to consume. 

References:
* https://stackoverflow.com/questions/64078308/how-to-write-a-cmake-file-which-successfully-links-gstreamer-basic-tutorial-5
* https://zhangboyi.gitlab.io/post/2020-09-14-resolve-dso-missing-from-command-line-error/#:~:text=The%20DSO%20missing%20from%20command,a%20directly%20specified%20dynamic%20library
* See `copy-dt-needed-entries` on https://linux.die.net/man/1/ld
* https://cmake.org/cmake/help/latest/module/FindPkgConfig.html