### PR TITLE
Use modern CMake

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,17 +13,9 @@ jobs:
       fail-fast: false
 
       matrix:
-        ros_distribution: [foxy, galactic, humble, rolling]
+        ros_distribution: [humble, rolling]
 
         include:
-          - ros_distribution: foxy
-            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
-            fix_libunwind: false
-
-          - ros_distribution: galactic
-            docker_image: rostooling/setup-ros-docker:ubuntu-focal-ros-galactic-ros-base-latest
-            fix_libunwind: false
-
           - ros_distribution: humble
             docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
             fix_libunwind: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 
 project(gscam2)
 
@@ -16,15 +16,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Emulate Colcon in CLion
-if($ENV{CLION_IDE})
-  message(STATUS "Running inside CLion")
-  find_package(fastrtps_cmake_module REQUIRED)
-  set(FastRTPS_INCLUDE_DIR "/opt/ros/foxy/include")
-  set(FastRTPS_LIBRARY_RELEASE "/opt/ros/foxy/lib/libfastrtps.so")
-  set(ros2_shared_DIR "${PROJECT_SOURCE_DIR}/../../../install/ros2_shared/share/ros2_shared/cmake")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DRUN_INSIDE_CLION")
-endif()
+# Default to SHARED, but user can turn this off to get STATIC
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 # Gstreamer doesn't provide CMake files
 find_package(PkgConfig REQUIRED)
@@ -41,37 +34,40 @@ find_package(rclpy REQUIRED)
 find_package(ros2_shared REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(include)
-
 # Create ament index resource which references the libraries in the binary dir
 set(node_plugins "")
+
+# How to build a library:
+# https://docs.ros.org/en/humble/How-To-Guides/Ament-CMake-Documentation.html#building-a-library
 
 #=============
 # GSCam node
 #=============
 
-set(GSCAM_NODE_DEPS
-  camera_calibration_parsers
-  camera_info_manager
-  class_loader
-  rclcpp
-  rclcpp_components
-  ros2_shared
-  sensor_msgs)
-
-add_library(gscam_node SHARED)
-target_sources(gscam_node PRIVATE src/gscam_node.cpp)
+add_library(gscam_node src/gscam_node.cpp)
 add_library(gscam2::gscam_node ALIAS gscam_node)
 
 target_compile_definitions(gscam_node
   PRIVATE "COMPOSITION_BUILDING_DLL")
 
-ament_target_dependencies(gscam_node
-  ${GSCAM_NODE_DEPS})
+target_include_directories(gscam_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(gscam_node PkgConfig::GSTREAMER PkgConfig::GST_APP)
-target_include_directories(gscam_node PUBLIC
-  "$<BUILD_INTERFACE:${GSTREAMER_INCLUDE_DIRS}>")
+target_link_libraries(gscam_node
+  PRIVATE
+    camera_calibration_parsers::camera_calibration_parsers
+    camera_info_manager::camera_info_manager
+    class_loader::class_loader
+    rclcpp_components::component
+    ros2_shared::ros2_shared
+    sensor_msgs::sensor_msgs_library
+  PUBLIC
+    rclcpp::rclcpp
+    PkgConfig::GSTREAMER
+    PkgConfig::GST_APP)
+
 rclcpp_components_register_nodes(gscam_node "gscam2::GSCamNode")
 set(node_plugins "${node_plugins}gscam2::GSCamNode;$<TARGET_FILE:gscam_node>\n")
 
@@ -79,23 +75,24 @@ set(node_plugins "${node_plugins}gscam2::GSCamNode;$<TARGET_FILE:gscam_node>\n")
 # Test subscriber node
 #=============
 
-set(SUBSCRIBER_NODE_SOURCES
-  src/subscriber_node.cpp)
-
-set(SUBSCRIBER_NODE_DEPS
-  class_loader
-  rclcpp
-  rclcpp_components
-  sensor_msgs)
-
-add_library(subscriber_node SHARED
-  ${SUBSCRIBER_NODE_SOURCES})
+add_library(subscriber_node src/subscriber_node.cpp)
+add_library(gscam2::subscriber_node ALIAS subscriber_node)
 
 target_compile_definitions(subscriber_node
   PRIVATE "COMPOSITION_BUILDING_DLL")
 
-ament_target_dependencies(subscriber_node
-  ${SUBSCRIBER_NODE_DEPS})
+target_include_directories(subscriber_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(subscriber_node
+  PRIVATE
+    class_loader::class_loader
+    rclcpp_components::component
+    sensor_msgs::sensor_msgs_library
+  PUBLIC
+    rclcpp::rclcpp)
 
 rclcpp_components_register_nodes(subscriber_node "gscam2::ImageSubscriberNode")
 set(node_plugins "${node_plugins}gscam2::ImageSubscriberNode;$<TARGET_FILE:subscriber_node>\n")
@@ -107,89 +104,68 @@ set(node_plugins "${node_plugins}gscam2::ImageSubscriberNode;$<TARGET_FILE:subsc
 add_executable(gscam_main
   src/gscam_main.cpp)
 
-ament_target_dependencies(gscam_main
-  ${GSCAM_NODE_DEPS})
-
-target_link_libraries(gscam_main gscam2::gscam_node)
+target_link_libraries(gscam_main
+  PRIVATE
+    gscam2::gscam_node)
 
 #=============
 # Manual composition of camera and subscriber nodes, IPC=true
 #=============
 
-add_executable(
-  ipc_test_main
-  src/ipc_test_main.cpp
-)
-target_link_libraries(
-  ipc_test_main
-  gscam_node
-  subscriber_node
-)
-ament_target_dependencies(
-  ipc_test_main
-  rclcpp
-)
+add_executable(ipc_test_main src/ipc_test_main.cpp)
+
+target_link_libraries(ipc_test_main
+  PRIVATE
+    gscam2::gscam_node
+    gscam2::subscriber_node
+    sensor_msgs::sensor_msgs_library)
 
 #=============
 # Test
 #=============
 
-# Load & run linters listed in package.xml
 if(BUILD_TESTING)
+  # Load & run linters listed in package.xml
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  # Smoke test
   find_package(ament_cmake_gtest)
-  ament_add_gtest(
-    smoke_test
+  ament_add_gtest(smoke_test
     test/smoke_test.cpp
-    ENV GSCAM_CONFIG="videotestsrc pattern=snow ! capsfilter caps=video/x-raw,width=800,height=600 ! videoconvert"
-  )
+    ENV GSCAM_CONFIG="videotestsrc pattern=snow ! capsfilter caps=video/x-raw,width=800,height=600 ! videoconvert")
   if(TARGET smoke_test)
-    target_link_libraries(smoke_test gscam_node)
+    target_link_libraries(smoke_test
+      gscam2::gscam_node
+      sensor_msgs::sensor_msgs_library)
   endif()
 endif()
-
-#=============
-# Export
-# Best practice, see https://discourse.ros.org/t/ament-best-practice-for-sharing-libraries/3602
-#=============
-
-ament_export_dependencies(class_loader)
-
-ament_export_include_directories(include)
-
-ament_export_targets(export_gscam_node export_subscriber_node)
-
-ament_export_libraries(gscam_node subscriber_node)
-
-ament_package()
 
 #=============
 # Install
 #=============
 
-install(DIRECTORY include/${PROJECT_NAME} DESTINATION include)
+install(DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include)
 
-install(
-  TARGETS gscam_node
-  EXPORT export_gscam_node
+install(TARGETS gscam_node subscriber_node
+  EXPORT gscam2_targets
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+  RUNTIME DESTINATION bin)
 
-install(
-  TARGETS subscriber_node
-  EXPORT export_subscriber_node
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+install(TARGETS gscam_main ipc_test_main
+  DESTINATION lib/${PROJECT_NAME})
 
-install(
-  TARGETS gscam_main ipc_test_main
-  DESTINATION lib/${PROJECT_NAME}
-)
+install(DIRECTORY cfg launch
+  DESTINATION share/${PROJECT_NAME})
 
-install(DIRECTORY cfg launch DESTINATION share/${PROJECT_NAME})
+#=============
+# Export targets, ament_export_targets will call "install(EXPORT ...)"
+#=============
+
+ament_export_targets(gscam2_targets HAS_LIBRARY_TARGET)
+
+ament_export_dependencies(rclcpp sensor_msgs)
+
+ament_package()

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
 
     <name>gscam2</name>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <description>
         ROS2 camera driver built around the GStreamer pipeline
         Port of https://github.com/ros-drivers/gscam


### PR DESCRIPTION
Adopt modern CMake practices.

* use CMake 3.12 (recommended minimum for Foxy)
* CLion workarounds no longer needed
* Add ALIAS for subscriber_node
* Fix exports so that downstream packages can find headers
* Use target_link_libraries() instead of ament_target_dependencies()
* Simplify code, other cleanups
* supports Humble and Rolling, I'll backport to Foxy and Galactic later